### PR TITLE
fixes adviser major comp display

### DIFF
--- a/pathways_vue/pages/major.vue
+++ b/pathways_vue/pages/major.vue
@@ -22,7 +22,7 @@
         </div>
 
         <d3-histogram />
-        <contact-adviser />
+        <contact-adviser-major />
       </div>
       <div v-else>
         PLACEHOLDER: select something


### PR DESCRIPTION
Just a little hotfix to display adviser comp on major page